### PR TITLE
feat(lint): add linting over the style guide examples (WIP)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -25,6 +25,8 @@ var globby = require("globby");
 var treeKill = require("tree-kill");
 var blc = require("broken-link-checker");
 
+var tslint = require('gulp-tslint');
+
 // TODO:
 //  1. Think about using runSequence
 //  2. Think about using spawn instead of exec in case of long error messages.
@@ -44,6 +46,7 @@ var docShredder = require(path.resolve(TOOLS_PATH, 'doc-shredder/doc-shredder'))
 var exampleZipper = require(path.resolve(TOOLS_PATH, '_example-zipper/exampleZipper'));
 var plunkerBuilder = require(path.resolve(TOOLS_PATH, 'plunker-builder/plunkerBuilder'));
 var fsUtils = require(path.resolve(TOOLS_PATH, 'fs-utils/fsUtils'));
+
 
 var _devguideShredOptions =  {
   examplesDir: path.join(DOCS_PATH, '_examples'),
@@ -494,6 +497,20 @@ gulp.task('_shred-clean-api', function(cb) {
 gulp.task('_zip-examples', function() {
   exampleZipper.zipExamples(_devguideShredOptions.examplesDir, _devguideShredOptions.zipDir);
   exampleZipper.zipExamples(_apiShredOptions.examplesDir, _apiShredOptions.zipDir);
+});
+
+
+// Linting
+
+gulp.task('lint', function() {
+  return gulp.src(['./public/docs/_examples/style-guide/ts/**/*.ts'])
+    .pipe(tslint({
+      rulesDirectory: ['node_modules/codelyzer/dist/src'],
+      configuration: require('./tslint.json')
+    }))
+    .pipe(tslint.report('prose', {
+      summarizeFailureOutput: true
+    }));
 });
 
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "harp": "harp",
     "live-server": "live-server",
     "test-api-builder": "jasmine-node tools/api-builder",
-
     "protractor": "protractor"
   },
   "repository": {
@@ -28,10 +27,11 @@
   "devDependencies": {
     "archiver": "^0.16.0",
     "assert-plus": "^0.1.5",
-    "broken-link-checker":"0.7.0",
+    "broken-link-checker": "0.7.0",
     "browser-sync": "^2.9.3",
     "canonical-path": "0.0.2",
     "cross-spawn": "^2.1.0",
+    "codelyzer": "0.0.13",
     "del": "^1.2.0",
     "dgeni": "^0.4.0",
     "dgeni-packages": "^0.11.1",
@@ -42,6 +42,7 @@
     "gulp": "^3.5.6",
     "gulp-env": "0.4.0",
     "gulp-task-listing": "^1.0.1",
+    "gulp-tslint": "^4.3.5",
     "gulp-util": "^3.0.6",
     "gulp-watch": "^4.3.4",
     "harp": "^0.20.3",
@@ -66,6 +67,7 @@
     "protractor": "^3.0.0",
     "q": "^1.4.1",
     "tree-kill": "^1.0.0",
+    "tslint": "^3.2.2",
     "typescript": "1.7.3",
     "yargs": "^3.23.0"
   },

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,101 @@
+{
+  "rules": {
+    "class-name": true,
+    "comment-format": [
+      true,
+      "check-space"
+    ],
+    "curly": true,
+    "eofline": true,
+    "forin": true,
+    "indent": [
+      true,
+      "spaces"
+    ],
+    "label-position": true,
+    "label-undefined": true,
+    "max-line-length": [
+      true,
+      140
+    ],
+    "member-access": false,
+    "member-ordering": [
+      true,
+      "static-before-instance",
+      "variables-before-functions"
+    ],
+    "no-arg": true,
+    "no-bitwise": true,
+    "no-console": [
+      true,
+      "debug",
+      "info",
+      "time",
+      "timeEnd",
+      "trace"
+    ],
+    "no-construct": true,
+    "no-debugger": true,
+    "no-duplicate-key": true,
+    "no-duplicate-variable": true,
+    "no-empty": false,
+    "no-eval": true,
+    "no-inferrable-types": true,
+    "no-shadowed-variable": true,
+    "no-string-literal": false,
+    "no-switch-case-fall-through": true,
+    "no-trailing-whitespace": true,
+    "no-unused-expression": true,
+    "no-unused-variable": true,
+    "no-unreachable": true,
+    "no-use-before-declare": true,
+    "no-var-keyword": true,
+    "object-literal-sort-keys": false,
+    "one-line": [
+      true,
+      "check-open-brace",
+      "check-catch",
+      "check-else",
+      "check-whitespace"
+    ],
+    "quotemark": [
+      true,
+      "single"
+    ],
+    "radix": true,
+    "semicolon": [
+      "always"
+    ],
+    "triple-equals": [
+      true,
+      "allow-null-check"
+    ],
+    "typedef-whitespace": [
+      true,
+      {
+        "call-signature": "nospace",
+        "index-signature": "nospace",
+        "parameter": "nospace",
+        "property-declaration": "nospace",
+        "variable-declaration": "nospace"
+      }
+    ],
+    "variable-name": false,
+    "whitespace": [
+      true,
+      "check-branch",
+      "check-decl",
+      "check-operator",
+      "check-separator",
+      "check-type"
+    ],
+    "component-selector-name": [true, "kebab-case"],
+    "component-selector-type": [true, "element"],
+    "host-parameter-decorator": true,
+    "input-parameter-decorator": true,
+    "output-parameter-decorator": true,
+    "attribute-parameter-decorator": true,
+    "input-property-directive": true,
+    "output-property-directive": true
+  }
+}


### PR DESCRIPTION
Add tslint with the ruleset of nglint (codelyzer) and perform linting over the style guide examples.

The tslint rules should be customized. In this PR I added only the style guide related once but the default set of rules also gets applied.
- We need to agree on a set of rules to apply over the code samples.
- @wardbell let me know if the build should fail in case any of the styles is not properly followed and if I need to do any other changes in order to wire it with the deployment process.
